### PR TITLE
Fix typo in prompt name

### DIFF
--- a/evaluation/template_list.py
+++ b/evaluation/template_list.py
@@ -4,7 +4,7 @@ template_list = {
         "guaranteed true",
         "can we infer",
         "GPT-3 style",
-        "does this impl",
+        "does this imply",
         "should assume",
         "does it follow that",
         "based on the previous passage",


### PR DESCRIPTION
Evaluation script fails with the template "does this impl" for RTE. The correct name is "does this imply".