### PR TITLE
Cap the number of examples to lenth of dataset if it is smaller than 100

### DIFF
--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -182,7 +182,7 @@ def main():
 
     # Trim a number of evaluation examples
     if args.debug:
-        raw_datasets = raw_datasets.select(range(100))
+        raw_datasets = raw_datasets.select(range(min(len(raw_datasets),100)))
 
     column_names = raw_datasets.column_names
 


### PR DESCRIPTION
When the debug flag is on, the current code will truncate the raw_dataset to 100 examples. This is buggy when the number of examples in the dataset is less than 100. This is fixed by taking the minimum between 100 and the number of examples in the dataset. i.e. `min(len(raw_datasets),100)`



e.g. 
`python ./evaluation/run_eval.py  --dataset_name super_glue --dataset_config_name cb --template_name "MNLI crowdsource" --model_name_or_path gpt2 --output_dir ./debug --per_device_eval_batch_size 1 --debug`

will give

````
07/01/2022 07:29:37 - INFO - __main__ - Distributed environment: NO
Num processes: 1
Process index: 0
Local process index: 0
Device: cpu

07/01/2022 07:29:37 - WARNING - datasets.builder - Reusing dataset super_glue (/root/.cache/huggingface/datasets/super_glue/cb/1.0.2/d040c658e2ddef6934fdd97deb45c777b6ff50c524781ea434e7219b56a428a7)
Traceback (most recent call last):
  File "./evaluation/run_eval.py", line 372, in <module>
    main()
  File "./evaluation/run_eval.py", line 185, in main
    raw_datasets = raw_datasets.select(range(100))
  File "/usr/local/lib/python3.7/dist-packages/datasets/arrow_dataset.py", line 518, in wrapper
    out: Union["Dataset", "DatasetDict"] = func(self, *args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/datasets/fingerprint.py", line 458, in wrapper
    out = func(self, *args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/datasets/arrow_dataset.py", line 3045, in select
    return self._select_contiguous(start, length, new_fingerprint=new_fingerprint)
  File "/usr/local/lib/python3.7/dist-packages/datasets/arrow_dataset.py", line 518, in wrapper
    out: Union["Dataset", "DatasetDict"] = func(self, *args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/datasets/fingerprint.py", line 458, in wrapper
    out = func(self, *args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/datasets/arrow_dataset.py", line 3106, in _select_contiguous
    _check_valid_indices_value(start + length - 1, len(self))
  File "/usr/local/lib/python3.7/dist-packages/datasets/arrow_dataset.py", line 605, in _check_valid_indices_value
    raise IndexError(f"Index {index} out of range for dataset of size {size}.")
IndexError: Index 99 out of range for dataset of size 56.