### PR TITLE
Fix padding side

### DIFF
--- a/debug/results.json
+++ b/debug/results.json
@@ -1,8 +1,0 @@
-{
-    "dataset_name": "super_glue",
-    "dataset_config_name": "cb",
-    "template_name": "GPT-3 style",
-    "evaluation": {
-        "accuracy": 0.39285714285714285
-    }
-}

--- a/debug/results.json
+++ b/debug/results.json
@@ -1,0 +1,8 @@
+{
+    "dataset_name": "super_glue",
+    "dataset_config_name": "cb",
+    "template_name": "GPT-3 style",
+    "evaluation": {
+        "accuracy": 0.39285714285714285
+    }
+}

--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -201,9 +201,9 @@ def main():
         )
 
     if args.tokenizer_name:
-        tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_name, use_fast=not args.use_slow_tokenizer)
+        tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_name, use_fast=not args.use_slow_tokenizer, padding_side="left")
     elif args.model_name_or_path:
-        tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, use_fast=not args.use_slow_tokenizer)
+        tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, use_fast=not args.use_slow_tokenizer, padding_side="left")
     else:
         raise ValueError(
             "You are instantiating a new tokenizer from scratch. This is not supported by this script."
@@ -265,8 +265,9 @@ def main():
         tokenized_targets = [
             tokenizer(
                 ans_choi,
-                padding=True,
-                max_length=args.target_max_length,
+                # padding is on the right here.
+                padding=False,
+                max_length=args.max_length,
                 truncation=True,
             )
             for ans_choi in answer_choices_texts

--- a/t0/model.py
+++ b/t0/model.py
@@ -81,16 +81,24 @@ class DecoderModel(ModelBase):
             self._model = AutoModelForCausalLM.from_config(config)
 
     def forward(self, batch):
+        device = batch["input_ids"].device
         _, prefix_length = batch["input_ids"].shape
+
+        _, labels_length = batch["labels"].shape
+        assert labels_length == 1, "Labels has to be a single token"
+
         model_inputs = {
             "input_ids": torch.cat([batch["input_ids"], batch["labels"]], dim=-1),
             "attention_mask": torch.cat([batch["attention_mask"], batch["labels_attention_mask"]], dim=-1),
         }
         # Set position ids correctly to take care of padding tokens between inputs_ids and labels
-        # Empty attention_mask is a forbidden value, ie full of zeros. In fact the first element should be 1 as the input
-        #   cannot be empty
-        assert torch.all(model_inputs["attention_mask"][:,0] == 1), "First element in the attention mask should be 1."
-        position_ids = torch.cumsum(model_inputs["attention_mask"].to(torch.long), dim=-1) - 1
+        # Empty attention_mask is a forbidden value, ie full of zeros.
+        # # TODO @thomasw21 not true when `padding_side="left"`
+        # assert torch.all(model_inputs["attention_mask"][:,0] == 1), "First element in the attention mask should be 1."
+        position_ids = torch.maximum(
+            torch.cumsum(model_inputs["attention_mask"].to(torch.long), dim=-1) - 1,
+            torch.zeros(1, dtype=torch.long, device=device)[None, None]
+        )
         model_inputs["position_ids"] = position_ids
 
         logits = self._model(**model_inputs).logits[:, prefix_length-1:-1]

--- a/t0/model.py
+++ b/t0/model.py
@@ -89,9 +89,6 @@ class DecoderModel(ModelBase):
             "attention_mask": torch.cat([batch["attention_mask"], batch["labels_attention_mask"]], dim=-1),
         }
         # Set position ids correctly to take care of padding tokens between inputs_ids and labels
-        # Empty attention_mask is a forbidden value, ie full of zeros.
-        # # TODO @thomasw21 not true when `padding_side="left"`
-        # assert torch.all(model_inputs["attention_mask"][:,0] == 1), "First element in the attention mask should be 1."
         position_ids = torch.maximum(
             torch.cumsum(model_inputs["attention_mask"].to(torch.long), dim=-1) - 1,
             torch.zeros(1, dtype=torch.long, device=device)[None, None]

--- a/t0/model.py
+++ b/t0/model.py
@@ -84,9 +84,6 @@ class DecoderModel(ModelBase):
         device = batch["input_ids"].device
         _, prefix_length = batch["input_ids"].shape
 
-        _, labels_length = batch["labels"].shape
-        assert labels_length == 1, "Labels has to be a single token"
-
         model_inputs = {
             "input_ids": torch.cat([batch["input_ids"], batch["labels"]], dim=-1),
             "attention_mask": torch.cat([batch["attention_mask"], batch["labels_attention_mask"]], dim=-1),


### PR DESCRIPTION
Fixes: #29 

As @kkawamu1 noticed, `<pad>` between `inputs` and `targets` is bad. Right now I've chose to use `padding_side="left"` as a fix. The current fix does:
```
<INPUT> <INPUT_PAD> <TARGET> <TARGET_PAD> -> <INPUT_PAD> <INPUT> <TARGET> <TARGET_PAD>
```

 The more permanent fix is to to do:
```
<INPUT> <INPUT_PAD> <TARGET> <TARGET_PAD> -> <INPUT> <TARGET> <INPUT_PAD> <TARGET_PAD>
```
This becomes especially useful when you start to leave the `text input | text target` paradigm so multiple step one.